### PR TITLE
Count directory sizes as 0 if excluded

### DIFF
--- a/src/kdirinfo.cpp
+++ b/src/kdirinfo.cpp
@@ -115,6 +115,9 @@ void KDirInfo::setMountPoint(bool isMountPoint) {
 }
 
 KFileSize KDirInfo::totalSize() {
+  if (_readState == KDirOnRequestOnly)
+      return 0;
+
   if (_summaryDirty)
     recalc();
 
@@ -122,6 +125,9 @@ KFileSize KDirInfo::totalSize() {
 }
 
 KFileSize KDirInfo::totalBlocks() {
+  if (_readState == KDirOnRequestOnly)
+      return 0;
+
   if (_summaryDirty)
     recalc();
 

--- a/src/kdirreadjob.cpp
+++ b/src/kdirreadjob.cpp
@@ -94,8 +94,6 @@ void KLocalDirReadJob::startReading() {
           if (S_ISDIR(statInfo.st_mode)) // directory child?
           {
             KDirInfo *subDir = new KDirInfo(entryName, &statInfo, _dir);
-            _dir->insertChild(subDir);
-            childAdded(subDir);
 
             if (KExcludeRules::excludeRules()->match(fullName)) {
               subDir->setExcluded();
@@ -121,6 +119,9 @@ void KLocalDirReadJob::startReading() {
                 }
               }
             }
+
+            _dir->insertChild(subDir);
+            childAdded(subDir);
           } else // non-directory child
           {
             if (entryName == DEFAULT_CACHE_NAME) // .kdirstat.cache.gz found?


### PR DESCRIPTION
If directories are excluded or considered a mountpoint and not crossed
into, their own self stat size is still counted. This is a problem for
mountpoints which report large sizes for directories (e.g. CephFS with
recursive stats enabled), as that gets counted even if the mountpoint is
not otherwise recursed into.

A simple solution is to just not count directory sizes in the subtree
total if they are marked as excluded.