### PR TITLE
Switch konqueror icon to system-file-manager

### DIFF
--- a/src/kstdcleanup.cpp
+++ b/src/kstdcleanup.cpp
@@ -24,7 +24,7 @@ KCleanup *KStdCleanup::openInKonqueror(QString &icon, QKeySequence &shortcut) {
   cleanup->setWorksForDotEntry(true);
   cleanup->setWorksLocalOnly(false);
   cleanup->setRefreshPolicy(KCleanup::noRefresh);
-  icon = "konqueror";
+  icon = "system-file-manager";
   shortcut = Qt::CTRL + Qt::Key_K;
   return cleanup;
 }


### PR DESCRIPTION
Konqueror is no longer the file manager in KDE.  This change will switch the icon to the default file manager (dolphin).