### PR TITLE
Remove %i from desktop file, fixing launch issue

### DIFF
--- a/src/k4dirstat.desktop
+++ b/src/k4dirstat.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=K4DirStat
-Exec=k4dirstat %i -qwindowtitle %c %u
+Exec=k4dirstat -qwindowtitle %c %u
 Icon=k4dirstat
 Type=Application
 X-DocPath=k4dirstat/index.html


### PR DESCRIPTION
Fixes #57
I'm not sure why this was here as it doesn't seem `--icon <icon>` was ever a valid option, and the icon is being set anyways in a hardcoded way as of ead2f9b